### PR TITLE
add background mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Awailable settings:
 **passwordCharacter** - Character, that used for password security mask. <br>
 **background** - Background, used for wallpaper (optional). <br>
 **backgroundFill** - Background Layer, used for layering the background. <br>
+**backgroundMode** - One of *aspect*, *fill*, *tile*, *none*. <br>
 
 
 # Contributions

--- a/where_is_my_sddm_theme/Main.qml
+++ b/where_is_my_sddm_theme/Main.qml
@@ -31,6 +31,24 @@ Rectangle {
         }
     }
 
+    function bgFillMode() {
+        switch(config.backgroundMode)
+        {
+            case "aspect":
+                return Image.PreserveAspectCrop;
+
+            case "fill":
+                return Image.Stretch;
+
+            case "tile":
+                return Image.Tile;
+
+            default:
+                return Image.Pad;
+        }
+    }
+
+
     Connections {
         target: sddm
         function onLoginFailed() {
@@ -92,7 +110,7 @@ Rectangle {
                 id: image
                 anchors.fill: parent
                 source: config.background
-                fillMode: Image.PreserveAspectCrop
+                fillMode: bgFillMode()
                 z: 2
               }
 

--- a/where_is_my_sddm_theme/theme.conf
+++ b/where_is_my_sddm_theme/theme.conf
@@ -2,3 +2,4 @@
 passwordCharacter=*
 background=
 backgroundFill=#000000
+backgroundFillMode=aspect


### PR DESCRIPTION
I want to use my distro's svg logo as background and I need set `fillMode` to `Image.Pad` to make it look good.