### PR TITLE
Add instructions to remove virtual keyboard in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Awailable settings:
  **usersFontSize** - Font size for users choose element.
  **sessionsFontSize** - Font size for sessions choose element.
 
+## Disable virtual keyboard
+
+You can disable virtual keyboard by setting line `InputMethod=qtvirtualkeyboard`
+to `InputMethod=` in sddm config file. SDDM config is located in `/etc/sddm.conf`
+(or `/etc/sddm.conf.d/kde_settings.conf`)
 
 # Contributions
 


### PR DESCRIPTION
Every time I set up this, I had to lookup the instructions to remove the virtual keyboard... so I thought it would be helpful to those who also lookup the same info.