### PR TITLE
feat: option to turn off use real name by default

### DIFF
--- a/where_is_my_sddm_theme/Main.qml
+++ b/where_is_my_sddm_theme/Main.qml
@@ -15,7 +15,7 @@ Rectangle {
     property int usernameRole: Qt.UserRole + 1
     property int realNameRole: Qt.UserRole + 2
     property int sessionNameRole: Qt.UserRole + 4
-    property string currentUsername: userModel.data(userModel.index(currentUsersIndex, 0), realNameRole) ||
+    property string currentUsername: (config.showUserRealNameByDefault=="true" && userModel.data(userModel.index(currentUsersIndex, 0), realNameRole)) ||
                                      userModel.data(userModel.index(currentUsersIndex, 0), usernameRole)
     property string currentSession: sessionModel.data(sessionModel.index(currentSessionsIndex, 0), sessionNameRole)
     property string passwordFontSize: config.passwordFontSize || 96

--- a/where_is_my_sddm_theme/theme.conf
+++ b/where_is_my_sddm_theme/theme.conf
@@ -25,6 +25,8 @@ sessionsFontSize=24
 showUsersByDefault=false
 # Font size of users choose label (in points)
 usersFontSize=48
+# Show user real name on label by default
+showUserRealNameByDefault=true
 
 # Path to background image
 background=

--- a/where_is_my_sddm_theme_qt5/Main.qml
+++ b/where_is_my_sddm_theme_qt5/Main.qml
@@ -15,7 +15,7 @@ Rectangle {
     property int usernameRole: Qt.UserRole + 1
     property int realNameRole: Qt.UserRole + 2
     property int sessionNameRole: Qt.UserRole + 4
-    property string currentUsername: userModel.data(userModel.index(currentUsersIndex, 0), realNameRole) ||
+    property string currentUsername: (config.showUserRealNameByDefault=="true" && userModel.data(userModel.index(currentUsersIndex, 0), realNameRole)) ||
                                      userModel.data(userModel.index(currentUsersIndex, 0), usernameRole)
     property string currentSession: sessionModel.data(sessionModel.index(currentSessionsIndex, 0), sessionNameRole)
     property string passwordFontSize: config.passwordFontSize || 96

--- a/where_is_my_sddm_theme_qt5/theme.conf
+++ b/where_is_my_sddm_theme_qt5/theme.conf
@@ -25,6 +25,8 @@ sessionsFontSize=24
 showUsersByDefault=false
 # Font size of users choose label (in points)
 usersFontSize=48
+# Show user real name on label by default
+showUserRealNameByDefault=true
 
 # Path to background image
 background=


### PR DESCRIPTION
this is a really small change I made locally and I think others could think it usefull. It creates an option so user can set off the default behaviour of using the user real name on the userchooser instead of the username.

This is my first open source contribution hope I got it right. 😅