### PR TITLE
Add option to allow submitting blank password

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Awailable settings:
 
 `passwordTextColor=` - Color of password input text
 
+`passwordAllowEmpty=false` - Allow blank password (e.g., if authentication is done by another PAM module)
+
 `showSessionsByDefault=false` - Show or not sessions choose label
 
 `sessionsFontSize=24` - Font size of sessions choose label (in points).

--- a/where_is_my_sddm_theme/Main.qml
+++ b/where_is_my_sddm_theme/Main.qml
@@ -232,7 +232,7 @@ Rectangle {
             passwordCharacter: config.stringValue("passwordCharacter") || "*"
             cursorVisible: config.boolValue("passwordInputCursorVisible")
             onAccepted: {
-                if (text != "") {
+                if (text != "" || config.boolValue("passwordAllowEmpty")) {
                     sddm.login(userModel.data(userModel.index(currentUsersIndex, 0), usernameRole)
  || "123test", text, currentSessionsIndex);
                 }

--- a/where_is_my_sddm_theme/theme.conf
+++ b/where_is_my_sddm_theme/theme.conf
@@ -15,6 +15,8 @@ passwordInputCursorVisible=true
 passwordFontSize=96
 passwordCursorColor=random
 passwordTextColor=
+# Allow blank password (e.g., if authentication is done by another PAM module)
+passwordAllowEmpty=false
 
 # Enable or disable cursor blink animation ("true" or "false")
 cursorBlinkAnimation=true

--- a/where_is_my_sddm_theme_qt5/Main.qml
+++ b/where_is_my_sddm_theme_qt5/Main.qml
@@ -231,7 +231,7 @@ Rectangle {
             passwordCharacter: config.passwordCharacter || "*"
             cursorVisible: config.passwordInputCursorVisible == "true" ? true : false
             onAccepted: {
-                if (text != "") {
+                if (text != "" || config.passwordAllowEmpty == "true") {
                     sddm.login(userModel.data(userModel.index(currentUsersIndex, 0), usernameRole)
  || "123test", text, currentSessionsIndex);
                 }

--- a/where_is_my_sddm_theme_qt5/theme.conf
+++ b/where_is_my_sddm_theme_qt5/theme.conf
@@ -15,6 +15,8 @@ passwordInputCursorVisible=true
 passwordFontSize=96
 passwordCursorColor=random
 passwordTextColor=
+# Allow blank password (e.g., if authentication is done by another PAM module)
+passwordAllowEmpty=false
 
 # Show or not sessions choose label
 showSessionsByDefault=false


### PR DESCRIPTION
Add configuration option to allow sddm.login to be called when the password is blank.

This is useful when another PAM module (for example, a security key is present) is sufficient for authenticating the user.

Made it a configuration option instead of default behaviour as I believe submitting an accidental blank password is a lot more likely than a user wanting to intentionally submit a blank password, so it's fine if the latter has to change a default first to allow their use case.