### PR TITLE
fix: switch was reading wrong config value

### DIFF
--- a/where_is_my_sddm_theme/Main.qml
+++ b/where_is_my_sddm_theme/Main.qml
@@ -44,7 +44,7 @@ Rectangle {
     }
 
     function bgFillMode() {
-        switch(config.stringValue("backgroundMode"))
+        switch(config.stringValue("backgroundFillMode"))
         {
             case "aspect":
                 return Image.PreserveAspectCrop;
@@ -374,4 +374,3 @@ Rectangle {
         }
     }
 }
-


### PR DESCRIPTION
switch was reading a config value that doesn't exist, exiting to default and making impossible to resize image correctfully